### PR TITLE
:bug: Make sure that action exits and displays an error message when the verification job fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ runs:
     - name: Verify project
       run: |
         verify-cmsis-example-sdk verify --project-dir ${{ inputs.project-directory }} --project-path ${{ inputs.project-file }} --out-dir out --api-key ${{ inputs.API_TOKEN }} --log-error 2
+        status=$?
+        if [ $status -ne 0 ]; then
+          echo "::error::Verification of CMSIS project failed"
+          exit 1
+        fi
       shell: bash
     - name: Upload any artifacts
       uses: actions/upload-artifact@v4

--- a/changes/20240704092901.bugfix
+++ b/changes/20240704092901.bugfix
@@ -1,0 +1,1 @@
+:bug: Make sure that action exits and displays an error message when the verification job fails


### PR DESCRIPTION
<!--
Copyright (C) 2020-2024 Arm Limited or its affiliates and Contributors. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->
### Description

<!--
Please add any detail or context that would be useful to a reviewer.
-->

Make sure that action exits and displays an error message when the verification job fails

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [ ]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
